### PR TITLE
Fix project open if multiple backends are found

### DIFF
--- a/src/Seascope.py
+++ b/src/Seascope.py
@@ -840,8 +840,8 @@ class SeascopeApp(QMainWindow):
 		proj_type = bl[0]
 		if len(bl) > 1:
 			msg = "Project '%s': Many backends interested" % proj_path
-			for b in be:
-				msg += '\n\t' + b.name()
+			for b in bl:
+				msg += '\n\t' + b
 			msg += '\n\nGoing ahead with: ' + proj_type
 			msg_box(msg)
 		print("Project '%s': using '%s' backend" % (proj_path, proj_type))


### PR DESCRIPTION
If multiple backends are detected (i.e. idutils and cscope), the program crashes with undefined variable `be`.